### PR TITLE
Add 'check-tpl' to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
       - docker exec build /bin/sh -c "mkdir -p /repo/build"
       - docker exec build /bin/sh -c "cd /repo/build && cmake -DCMAKE_BUILD_TYPE=debug -DTERRIER_GENERATE_COVERAGE=ON  -DTERRIER_BUILD_BENCHMARKS=OFF .."
       - docker exec build /bin/sh -c "cd /repo/build && make unittest -j 4"
+      - docker exec build /bin/sh -c "cd /repo/build && make check-tpl"
       - docker exec build /bin/sh -c "cd /repo/build && lcov --directory . --capture --output-file coverage.info" # capture coverage info
       - docker exec build /bin/sh -c "cd /repo/build && lcov --remove coverage.info '/usr/*' --output-file coverage.info" # filter out system
       - docker exec build /bin/sh -c "cd /repo/build && lcov --remove coverage.info '*/build/*' --output-file coverage.info" # filter out build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && gtimeout 1h make unittest'
+                        sh 'cd build && gtimeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -36,6 +37,7 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
+                        sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -57,6 +59,7 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
+                        sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -72,6 +75,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
                         sh 'cd build && gtimeout 1h make unittest'
+                        sh 'cd build && gtimeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }
@@ -87,6 +91,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
                         sh 'cd build && timeout 1h make unittest'
+                        sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }
@@ -106,6 +111,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
                         sh 'cd build && timeout 1h make unittest'
+                        sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }


### PR DESCRIPTION
Adds a call to 'make check-tpl' immediately after all invocations of 'make unittest' in our CI pipelines.  Runs on both Travis and Jenkins and is currently identifying issues with TPL results on macOS builds.